### PR TITLE
chore: use new repo URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 authors = [
     "Volker Mische <volker.mische@gmail.com>"
 ]
-repository = "https://github.com/vmx/ipld-dagpb"
+repository = "https://github.com/ipld/rust-ipld-dagpb"
 edition = "2021"
 description = "IPLD DAG-PB codec."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The repository was moved from my personal account to the ipld org account, reflect that in the Cargo metadata.