### PR TITLE
feat: implement Codec trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
-
-[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,11 +75,10 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ipld-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6f85d53216cdc216013670266c6b2a3ec8ddd3eaa077ee5042d71c2d5fa775"
+checksum = "0a2587b73a610af0133af0409ca9aaeed7d4e750eabd4d9f035a85e70fe3d7fe"
 dependencies = [
- "anyhow",
  "cid",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["data-structures", "encoding"]
 
 [dependencies]
 bytes = "1.3.0"
-ipld-core = "0.2.0"
+ipld-core = "0.3.0"
 quick-protobuf = "0.8.1"
 thiserror = "1.0.25"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,4 +12,7 @@ pub enum Error {
     /// When there is an error during the buffers buffers encoding.
     #[error("cannot encode protocol buffers")]
     ToPb(#[from] quick_protobuf::Error),
+    /// When there is an error with the reader or writer.
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
 }

--- a/tests/codec.rs
+++ b/tests/codec.rs
@@ -1,0 +1,51 @@
+use std::{collections::BTreeMap, iter};
+
+use ipld_core::{
+    cid::Cid,
+    codec::{Codec, Links},
+    ipld,
+    ipld::Ipld,
+};
+use ipld_dagpb::{DagPbCodec, PbNode};
+
+fn gen_ipld_node() -> Ipld {
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let pb_link = ipld!({
+        "Hash": cid,
+        "Name": "block",
+        "Tsize": 13,
+    });
+
+    let links: Vec<Ipld> = vec![pb_link.clone(), pb_link];
+    let mut pb_node = BTreeMap::<String, Ipld>::new();
+    pb_node.insert("Data".to_string(), b"Here is some data\n".to_vec().into());
+    pb_node.insert("Links".to_string(), links.into());
+    pb_node.into()
+}
+
+#[test]
+fn test_codec_ipld_encode_decode() {
+    let ipld = gen_ipld_node();
+    let bytes = DagPbCodec::encode_to_vec(&ipld).unwrap();
+    let ipld2 = DagPbCodec::decode_from_slice(&bytes).unwrap();
+    assert_eq!(ipld, ipld2);
+}
+
+#[test]
+fn test_codec_pbnode_encode_decode() {
+    let ipld = gen_ipld_node();
+    let bytes = DagPbCodec::encode_to_vec(&ipld).unwrap();
+    let pb_node: PbNode = DagPbCodec::decode_from_slice(&bytes).unwrap();
+    let bytes2 = DagPbCodec::encode_to_vec(&pb_node).unwrap();
+    assert_eq!(bytes, bytes2);
+}
+
+#[test]
+fn test_codec_links() {
+    let ipld = gen_ipld_node();
+    let bytes = DagPbCodec::encode_to_vec(&ipld).unwrap();
+    let links = DagPbCodec::links(&bytes).unwrap().collect::<Vec<_>>();
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let expected = iter::repeat(cid).take(2).collect::<Vec<_>>();
+    assert_eq!(links, expected);
+}


### PR DESCRIPTION
The `Codec` trait from `ipld-core` allows unified access for encoding, decoding and extracting links of encoded IPLD data independent of the codec.

Also make `PbNode` public, in case you want to decode directly into a Rust struct and not an IPLD object.