### PR TITLE
Derive common traits for `DagPbCodec`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub fn links(bytes: &[u8], links: &mut impl Extend<Cid>) -> Result<(), Error> {
 }
 
 /// DAG-PB implementation of ipld-core's `Codec` trait.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DagPbCodec;
 
 impl Codec<Ipld> for DagPbCodec {


### PR DESCRIPTION
See https://github.com/ipld/serde_ipld_dagcbor/pull/32 for more (this is the DAG-PB equivalent)