### PR TITLE
fix: expose PbLink

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use ipld_core::{
 };
 
 use crate::codec::PbNodeRef;
-pub use crate::{codec::PbNode, error::Error};
+pub use crate::{codec::PbLink, codec::PbNode, error::Error};
 
 /// Convert from [`ipld_core::ipld::Ipld`] into serialized DAG-PB.
 pub fn from_ipld(ipld: &Ipld) -> Result<Vec<u8>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use ipld_core::{
 };
 
 use crate::codec::PbNodeRef;
-pub use crate::{codec::PbLink, codec::PbNode, error::Error};
+pub use crate::{codec::{PbLink, PbNode}, error::Error};
 
 /// Convert from [`ipld_core::ipld::Ipld`] into serialized DAG-PB.
 pub fn from_ipld(ipld: &Ipld) -> Result<Vec<u8>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,10 @@ use ipld_core::{
 };
 
 use crate::codec::PbNodeRef;
-pub use crate::{codec::{PbLink, PbNode}, error::Error};
+pub use crate::{
+    codec::{PbLink, PbNode},
+    error::Error,
+};
 
 /// Convert from [`ipld_core::ipld::Ipld`] into serialized DAG-PB.
 pub fn from_ipld(ipld: &Ipld) -> Result<Vec<u8>, Error> {


### PR DESCRIPTION
Doesn't make a lot of sense to have `PbNode` be exposed along with its links field but not be able to use `PbLink`