### PR TITLE
chore: fix Clippy warnings

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -285,7 +285,7 @@ impl MessageWrite for PbLink {
         size += 1 + sizeof_len(l);
 
         if let Some(ref name) = self.name {
-            size += 1 + sizeof_len(name.as_bytes().len());
+            size += 1 + sizeof_len(name.len());
         }
 
         if let Some(tsize) = self.size {

--- a/tests/codec.rs
+++ b/tests/codec.rs
@@ -46,6 +46,6 @@ fn test_codec_links() {
     let bytes = DagPbCodec::encode_to_vec(&ipld).unwrap();
     let links = DagPbCodec::links(&bytes).unwrap().collect::<Vec<_>>();
     let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
-    let expected = iter::repeat(cid).take(2).collect::<Vec<_>>();
+    let expected = iter::repeat_n(cid, 2).collect::<Vec<_>>();
     assert_eq!(links, expected);
 }


### PR DESCRIPTION
`len()` on a String really returns the byte length and not the number of Unicode code points:

  https://doc.rust-lang.org/1.89.0/std/string/struct.String.html#method.len