### PR TITLE
feat: make the DAG-PB multicodec code public

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -285,7 +285,7 @@ impl MessageWrite for PbLink {
         size += 1 + sizeof_len(l);
 
         if let Some(ref name) = self.name {
-            size += 1 + sizeof_len(name.as_bytes().len());
+            size += 1 + sizeof_len(name.len());
         }
 
         if let Some(tsize) = self.size {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ pub use crate::{
     error::Error,
 };
 
+/// The multicodec code for DAG-PB.
+pub const DAG_PB_CODE: u64 = 0x70;
+
 /// Convert from [`ipld_core::ipld::Ipld`] into serialized DAG-PB.
 pub fn from_ipld(ipld: &Ipld) -> Result<Vec<u8>, Error> {
     let node: PbNodeRef = ipld.try_into()?;
@@ -45,7 +48,7 @@ pub fn links(bytes: &[u8], links: &mut impl Extend<Cid>) -> Result<(), Error> {
 pub struct DagPbCodec;
 
 impl Codec<Ipld> for DagPbCodec {
-    const CODE: u64 = 0x70;
+    const CODE: u64 = DAG_PB_CODE;
     type Error = Error;
 
     fn decode<R: BufRead>(mut reader: R) -> Result<Ipld, Self::Error> {
@@ -71,7 +74,7 @@ impl Links for DagPbCodec {
 }
 
 impl Codec<PbNode> for DagPbCodec {
-    const CODE: u64 = 0x70;
+    const CODE: u64 = DAG_PB_CODE;
     type Error = Error;
 
     fn decode<R: BufRead>(mut reader: R) -> Result<PbNode, Self::Error> {

--- a/tests/codec.rs
+++ b/tests/codec.rs
@@ -46,6 +46,6 @@ fn test_codec_links() {
     let bytes = DagPbCodec::encode_to_vec(&ipld).unwrap();
     let links = DagPbCodec::links(&bytes).unwrap().collect::<Vec<_>>();
     let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
-    let expected = iter::repeat(cid).take(2).collect::<Vec<_>>();
+    let expected = iter::repeat_n(cid, 2).collect::<Vec<_>>();
     assert_eq!(links, expected);
 }


### PR DESCRIPTION
There is no easy way to get the DAG-PB multicodec code from this library. This commits adds a public constant called `DAG_PB_CODE`.